### PR TITLE
EZEE-1506: Cannot generate Form preview with Captcha field	

### DIFF
--- a/app/Resources/EzSystemsFormBuilderBundle/views/fields/captcha/basic.html.twig
+++ b/app/Resources/EzSystemsFormBuilderBundle/views/fields/captcha/basic.html.twig
@@ -1,8 +1,7 @@
 {% extends 'EzSystemsFormBuilderBundle:fields:field.html.twig' %}
 {% trans_default_domain "formcaptcha" %}
 
-{% set normalizedId = field.id|replace('-', '_') %}
-{% set imageId = 'captcha__' ~ normalizedId %}
+{% set imageId = 'captcha__' ~ field.id|replace({'-': '_'}) %}
 {% set captchaImage = ez_form_captcha_path(field) %}
 
 {% block input %}


### PR DESCRIPTION
> JIRA: https://jira.ez.no/browse/EZEE-1506

# Description
One `replace` filter call in Twig template was invalid as it was using similar scheme to the php's `str_replace`. This scheme was deprecated in Twig 2.x thus an exception was being thrown.

# Testing
Please retest manually on the page and in Landing Page view/edit modes.