### PR TITLE
Adding new mount required for installation

### DIFF
--- a/.platform.app.yaml
+++ b/.platform.app.yaml
@@ -41,6 +41,8 @@ mounts:
     "/web/var": "shared:files/files"
     # Might want to not mount this one, it will slow down sessions, if you need cluster use memcached/redis!
     "/var/sessions": "shared:files/sessions"
+    # Installation Migrations generate files on the fly, so this is required
+    "/src/AppBundle/MigrationVersions/References": "shared:files/src/AppBundle/MigrationVersions/References"
 
 # The hooks that will be performed when the package is deployed.
 hooks:


### PR DESCRIPTION
On installation with `bin/console ezplatform:install platform-ee-demo` the installer will generate new files to the directory `/src/AppBundle/MigrationVersions/References`.

This PR adds this directory to the list of writable mounts so the installation script can be executed.