### PR TITLE
DEMO-169: Pagelayout is not defined in configuration

### DIFF
--- a/app/config/ezplatform.yml
+++ b/app/config/ezplatform.yml
@@ -60,6 +60,7 @@ ezpublish:
                     service_id: '%fastly_service_id%'
                     key: '%fastly_key%'
             design: main
+            pagelayout: '@ezdesign/pagelayout.html.twig'
         # WARNING: Do not remove or rename this group.
         admin_group:
             cache_service_name: '%cache_pool%'


### PR DESCRIPTION
> JIRA: https://jira.ez.no/browse/DEMO-169

This PR adds `pagelayout` to `site_group`. It's crucial for Page Builder when creating new page, it uses this value to compose an empty page.