### PR TITLE
Use Cards layout in default Content List configuration

### DIFF
--- a/tests/AppBundle/Behat/PageElement/Blocks/DemoContentListBlock.php
+++ b/tests/AppBundle/Behat/PageElement/Blocks/DemoContentListBlock.php
@@ -16,6 +16,8 @@ class DemoContentListBlock extends ContentListBlock
         $this->addContent('Home/Places & Tastes/Tastes');
         $this->setInputField('Limit', '5');
         $this->selectContentType('Article');
+        $this->switchTab('Design');
+        $this->setLayout('cards');
         $this->submitForm();
     }
 


### PR DESCRIPTION
After https://github.com/ezsystems/ezplatform-page-fieldtype/pull/80 is merged the default layout is no longer used, but ContentList block has more than one layout defined (it has 4). 

After all this changes the layout selected by default switched from Cards to Blog - as the behaviour is now configurable I don't think we need to do anything more in the product, I'm adjusting the tests to select the layout we're expecting.

Example failure that this PR fixes: https://travis-ci.com/ezsystems/ezplatform-page-builder/jobs/174194996