### PR TITLE
Use direct Composer path

### DIFF
--- a/bin/.travis/trusty/setup_ezplatform.sh
+++ b/bin/.travis/trusty/setup_ezplatform.sh
@@ -93,6 +93,6 @@ echo '> Change ownership of files inside docker container'
 docker-compose exec app sh -c 'chown -R www-data:www-data /var/www'
 
 echo '> Install data'
-docker-compose exec --user www-data app sh -c "php /scripts/wait_for_db.php; php -d memory_limit=${COMPOSER_MEMORY_LIMIT} `which composer` ezplatform-install"
+docker-compose exec --user www-data app sh -c "php /scripts/wait_for_db.php; php -d memory_limit=${COMPOSER_MEMORY_LIMIT} /usr/local/bin/composer ezplatform-install"
 
 echo '> Done, ready to run tests'


### PR DESCRIPTION
Currently tests using Demo are failing: https://travis-ci.com/ezsystems/ezplatform-page-builder/builds/102970176

``which composer`` evaluates to `/home/travis/.phpenv/shims/composer` on Travis VMs, but the command is meant to be executed inside Docker container (where such file does not exist).

Changing it direct Compose path solves the issue.