### PR TITLE
Fixed missing automated translation javascript asset for docker installations

### DIFF
--- a/.env
+++ b/.env
@@ -35,3 +35,6 @@ SELENIUM_HOST=selenium
 # In order for this to work you also need to have the EE bundle EzSystemsPlatformFastlyCacheBundle installed
 #FASTLY_SERVICE_ID=""
 #FASTLY_KEY=""
+
+# Enable automated translation by setting valid google translate api key
+#GOOGLE_TRANSLATE_API_KEY=""

--- a/doc/docker/Dockerfile-distribution
+++ b/doc/docker/Dockerfile-distribution
@@ -3,6 +3,8 @@
 ARG DISTRIBUTION_IMAGE=docker_app
 FROM ${DISTRIBUTION_IMAGE} as builder
 
+ENV GOOGLE_TRANSLATE_API_KEY=MustBeSetInOrderToDumpAssetsOfEzPlatformAutomatedTranslationBundle
+
 RUN composer config extra.symfony-assets-install hard
 RUN composer run-script post-install-cmd --no-interaction
 

--- a/doc/docker/base-dev.yml
+++ b/doc/docker/base-dev.yml
@@ -24,6 +24,7 @@ services:
      - PUBLIC_SERVER_URI
      - FASTLY_SERVICE_ID
      - FASTLY_KEY
+     - GOOGLE_TRANSLATE_API_KEY
     networks:
      - backend
 

--- a/doc/docker/base-prod.yml
+++ b/doc/docker/base-prod.yml
@@ -25,6 +25,7 @@ services:
      - PUBLIC_SERVER_URI
      - FASTLY_SERVICE_ID
      - FASTLY_KEY
+     - GOOGLE_TRANSLATE_API_KEY
     networks:
      - backend
 

--- a/doc/docker/distribution.yml
+++ b/doc/docker/distribution.yml
@@ -31,6 +31,7 @@ services:
      - RECOMMENDATIONS_CUSTOMER_ID
      - RECOMMENDATIONS_LICENSE_KEY
      - PUBLIC_SERVER_URI
+     - GOOGLE_TRANSLATE_API_KEY
     networks:
      - backend
     volumes:

--- a/doc/docker/install.yml
+++ b/doc/docker/install.yml
@@ -28,6 +28,7 @@ services:
      - DATABASE_PASSWORD
      - DATABASE_NAME
      - DATABASE_HOST=install_db
+     - GOOGLE_TRANSLATE_API_KEY
     # Dumping autoload using --optimize-autoloader to keep performenace on a usable level, not needed on linux host.
     # Second chown line:  For dev and behat tests we give a bit extra rights, never do this for prod.
     command: >


### PR DESCRIPTION
Javascript asset was not dumped during installation in docker containers due to missing GOOGLE_TRANSLATE_API_KEY env variable.

As far as I can see the automated translation is enabled only for ezplatform-ee-demo, hence the PR against this repo and not ezplatform-ee.