### PR TITLE
Fix for ezplatform-ee-demo schema installer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -74,7 +74,7 @@
         "kaliop/ezmigrationbundle": "^5.9",
         "knplabs/knp-menu-bundle": "^2.2.1",
         "leafo/scssphp": "^0.7.7",
-        "netgen/tagsbundle": "^3.4",
+        "netgen/tagsbundle": "^3.4.1",
         "novactive/ezseobundle": "^3.0.0@rc",
         "oneup/flysystem-bundle": "^3.0",
         "overblog/graphql-bundle": "^0.11.11",

--- a/src/AppBundle/Resources/schema/demo.yaml
+++ b/src/AppBundle/Resources/schema/demo.yaml
@@ -1,46 +1,4 @@
 tables:
-    # NetGen Tags Bundle
-    eztags:
-        indexes:
-            idx_eztags_keyword_id: { fields: [keyword, id] }
-            idx_eztags_keyword: { fields: [keyword] }
-        uniqueConstraints:
-            idx_eztags_remote_id: { fields: [remote_id] }
-        id:
-            id: { type: integer, nullable: false, options: { autoincrement: true } }
-        fields:
-            parent_id: { type: integer, nullable: false, options: { default: '0' } }
-            main_tag_id: { type: integer, nullable: false, options: { default: '0' } }
-            keyword: { type: string, nullable: false, length: 255, options: { default: '' } }
-            depth: { type: integer, nullable: false, options: { default: '1' } }
-            path_string: { type: string, nullable: false, length: 255, options: { default: '' } }
-            modified: { type: integer, nullable: false, options: { default: '0' } }
-            remote_id: { type: string, nullable: false, length: 100, options: { default: '' } }
-            main_language_id: { type: integer, nullable: false, options: { default: '0' } }
-            language_mask: { type: integer, nullable: false, options: { default: '0' } }
-    eztags_attribute_link:
-        indexes:
-            idx_eztags_attr_link_kid_oaid_oav: { fields: [keyword_id, objectattribute_id, objectattribute_version] }
-            idx_eztags_attr_link_kid_oid: { fields: [keyword_id, object_id] }
-            idx_eztags_attr_link_oaid_oav: { fields: [objectattribute_id, objectattribute_version] }
-            idx_eztags_attr_link_keyword_id: { fields: [keyword_id] }
-        id:
-            id: { type: integer, nullable: false, options: { autoincrement: true } }
-        fields:
-            keyword_id: { type: integer, nullable: false, options: { default: '0' } }
-            objectattribute_id: { type: integer, nullable: false, options: { default: '0' } }
-            objectattribute_version: { type: integer, nullable: false, options: { default: '0' } }
-            object_id: { type: integer, nullable: false, options: { default: '0' } }
-            priority: { type: integer, nullable: false, options: { default: '0' } }
-    eztags_keyword:
-        id:
-            keyword_id: { type: integer, nullable: false, options: { default: '0' } }
-            locale: { type: string, nullable: false, length: 255, options: { default: '' } }
-        fields:
-            language_id: { type: integer, nullable: false, options: { default: '0' } }
-            keyword: { type: string, nullable: false, length: 255, options: { default: '' } }
-            status: { type: integer, nullable: false, options: { default: '0' } }
-
     # Nova eZ SEO Bundle
     novaseo_meta:
         indexes:


### PR DESCRIPTION
There is exception during the ezplatform install:

 
In SchemaException.php line 108:

The table with name 'public.eztags' already exists.
 
moved here: https://github.com/netgen/TagsBundle/blob/master/bundle/Resources/schema/legacy.yml
