### PR TITLE
Adjust image path for tests

### DIFF
--- a/tests/App/Behat/PageElement/Blocks/DemoVideoBlock.php
+++ b/tests/App/Behat/PageElement/Blocks/DemoVideoBlock.php
@@ -19,6 +19,6 @@ class DemoVideoBlock extends VideoBlock
 
     public function getDefaultPreviewData(): array
     {
-        return ['parameter1' => '/var/site/storage/images/7/7/6/1/1677-1-eng-GB/Our-Picks.jpg'];
+        return ['parameter1' => '/var/site/storage/images/9/3/4/1/1439-1-eng-GB/Our-Picks.jpg'];
     }
 }


### PR DESCRIPTION
There is only one failure in https://travis-ci.com/ezsystems/ezplatform-page-builder/jobs/224288222 , which is because the tests use a hardcoded path to image (which somehow changed).

I know that this is a quickfix, but the path is constant between reruns, so not sure we need a better solution here 😉 