### PR TITLE
Improve method naming for EndWorkflowSubscriber

### DIFF
--- a/src/Event/Subscriber/EndWorkflowSubscriber.php
+++ b/src/Event/Subscriber/EndWorkflowSubscriber.php
@@ -96,13 +96,13 @@ class EndWorkflowSubscriber implements EventSubscriberInterface
 
             $workflowCurrentState = !empty($workflowMetadata->markings) ? end($workflowMetadata->markings)->name : '';
             $transitions = $workflowMetadata->workflow->getDefinition()->getTransitions();
-            $lastStage = $this->getLastStage($transitions, $workflow->getName());
+            $transitionToLastStage = $this->getTransitionToLastStage($transitions, $workflow->getName());
 
             if (!$lastStage) {
                 continue;
             }
 
-            $transitionsToMake = $this->findPathToInitialStage($transitions, $workflowCurrentState, $lastStage);
+            $transitionsToMake = $this->findPathToLastStage($transitions, $workflowCurrentState, $transitionToLastStage);
             $this->applyTransitions($transitionsToMake, $workflowMetadata);
         }
     }
@@ -122,7 +122,7 @@ class EndWorkflowSubscriber implements EventSubscriberInterface
         }
     }
 
-    private function getLastStage(array $transitions, string $workflowName): ?Transition
+    private function getTransitionToLastStage(array $transitions, string $workflowName): ?Transition
     {
         $workflowDefinitionMetadata = $this->workflowMetadataRegistry->getWorkflowMetadata($workflowName);
 
@@ -138,7 +138,7 @@ class EndWorkflowSubscriber implements EventSubscriberInterface
         return null;
     }
 
-    private function findPathToInitialStage(array $transitions, string $workflowCurrentState, Transition $transition)
+    private function findPathToLastStage(array $transitions, string $workflowCurrentState, Transition $transition)
     {
         $path = [$transition->getName()];
 


### PR DESCRIPTION
**rename: getLastStage -> getTransitionToLastStage :**
method actually returns a transition object

**rename:  findPathToInitialStage -> findPathToLastStage :**
return array $path is array with  end($path) = $transitionToLastStage->getName()