### PR TITLE
EZP-30898: Refactored to use new DbBasedInstaller DIC service name

### DIFF
--- a/config/services/installer.yaml
+++ b/config/services/installer.yaml
@@ -7,7 +7,7 @@ services:
     App\Installer\PlatformEEDemoInstaller:
         autowire: true
         autoconfigure: false
-        parent: ezplatform.installer.db_based_installer
+        parent: EzSystems\PlatformInstallerBundle\Installer\DbBasedInstaller
         calls:
             - [setEnvironment, ["%kernel.environment%"]]
         tags:
@@ -16,7 +16,7 @@ services:
     App\Installer\PlatformEEDemoTestLayoutsInstaller:
         autowire: true
         autoconfigure: false
-        parent: ezplatform.installer.db_based_installer
+        parent: EzSystems\PlatformInstallerBundle\Installer\DbBasedInstaller
         calls:
             - [setEnvironment, ["%kernel.environment%"]]
         tags:


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-30898](https://jira.ez.no/browse/EZP-30898)
| **Requires** | ezsystems/ezpublish-kernel#2751
| **Bug/Improvement**| yes
| **New feature**    | no
| **Target version** | eZ Platform EE Demo `v3.0`
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

New service name, coming from ezpublish-kernel, is FQCN-based: `EzSystems\PlatformInstallerBundle\Installer\DbBasedInstaller`.