### PR TITLE
Changed how VideoBlockPreview is verified

### DIFF
--- a/tests/App/Behat/PageElement/BlockPreview/DemoVideoPreview.php
+++ b/tests/App/Behat/PageElement/BlockPreview/DemoVideoPreview.php
@@ -27,6 +27,11 @@ class DemoVideoPreview extends VideoPreview
 
     public function verifyVisibility(): void
     {
-        Assert::assertStringEndsWith($this->imageFilename, $this->context->findElement($this->fields['imgSelector'], self::TIMEOUT, $this->baseElement)->getAttribute('src'));
+        Assert::assertStringEndsWith(
+            $this->imageFilename,
+            $this->context
+                ->findElement($this->fields['imgSelector'], self::TIMEOUT, $this->baseElement)
+                ->getAttribute('src')
+        );
     }
 }

--- a/tests/App/Behat/PageElement/BlockPreview/DemoVideoPreview.php
+++ b/tests/App/Behat/PageElement/BlockPreview/DemoVideoPreview.php
@@ -27,6 +27,6 @@ class DemoVideoPreview extends VideoPreview
 
     public function verifyVisibility(): void
     {
-        Assert::assertEquals($this->imageFilename, $this->context->findElement($this->fields['imgSelector'], self::TIMEOUT, $this->baseElement)->getAttribute('src'));
+        Assert::assertStringEndsWith($this->imageFilename, $this->context->findElement($this->fields['imgSelector'], self::TIMEOUT, $this->baseElement)->getAttribute('src'));
     }
 }

--- a/tests/App/Behat/PageElement/Blocks/DemoVideoBlock.php
+++ b/tests/App/Behat/PageElement/Blocks/DemoVideoBlock.php
@@ -19,6 +19,6 @@ class DemoVideoBlock extends VideoBlock
 
     public function getDefaultPreviewData(): array
     {
-        return ['parameter1' => '/var/site/storage/images/9/3/4/1/1439-1-eng-GB/Our-Picks.jpg'];
+        return ['parameter1' => 'Our-Picks.jpg'];
     }
 }


### PR DESCRIPTION
The EE demo tests are failing with:
```
        Failed asserting that two strings are equal.
        --- Expected
        +++ Actual
        @@ @@
        -'/var/site/storage/images/9/3/4/1/1439-1-eng-GB/Our-Picks.jpg'
        +'/var/site/storage/images/7/3/4/1/1437-1-eng-GB/Our-Picks.jpg'
```
Link to build: https://travis-ci.com/ezsystems/ezplatform-page-builder/jobs/240556635

This PR changes how the verifications is done (we should only care about the image name, not the rest of the path).