### PR TITLE
EZP-3085: Added content-type validation for Gallery and Video

### DIFF
--- a/config/packages/blocks.yml
+++ b/config/packages/blocks.yml
@@ -1,5 +1,22 @@
 ezplatform_page_fieldtype:
     blocks:
+        gallery:
+            attributes:
+                contentId:
+                    validators:
+                        content_type:
+                            message: You must select a Folder or Gallery
+                            options:
+                                types: ['folder', 'gallery']
+        video:
+            attributes:
+                contentId:
+                    validators:
+                        content_type:
+                            message: You must select an Video
+                            options:
+                                types: video
+
 #        hero:
 #            name: Hero
 #            category: default
@@ -26,4 +43,8 @@ ezplatform_page_fieldtype:
 #                            options:
 #                                pattern: '/[0-9]+/'
 #                            message: Choose a Content item
+#                        content_type:
+#                            message: You must select an Image
+#                            options:
+#                                types: image
 #

--- a/config/packages/universal_discovery_widget.yaml
+++ b/config/packages/universal_discovery_widget.yaml
@@ -1,0 +1,11 @@
+ezpublish:
+  system:
+    default:
+      universal_discovery_widget_module:
+        configuration:
+          block_gallery:
+            multiple: false
+            allowed_content_types: ['folder', 'gallery']
+          block_video:
+            multiple: false
+            allowed_content_types: ['video']

--- a/config/packages/universal_discovery_widget.yaml
+++ b/config/packages/universal_discovery_widget.yaml
@@ -6,6 +6,6 @@ ezpublish:
           block_gallery:
             multiple: false
             allowed_content_types: ['folder', 'gallery']
-          block_video:
+          embed_video:
             multiple: false
             allowed_content_types: ['video']


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [EZEE-3085](https://jira.ez.no/browse/EZEE-3085)
| **Type**                                   | improvement
| **BC breaks**                          | no
| **Tests pass**                          | yes
| **Doc needed**                       | yes

Added validations for Gallery and Video FieldTypes in PageBuilder

Related PRs:
ezsystems/ezplatform-form-builder/pull/226
ezsystems/ezplatform-page-fieldtype#141
ezsystems/ezplatform-kernel#47
ezsystems/ezplatform-page-builder/pull/568

#### Checklist:
- [x] Added code follows Coding Standards (use `$ composer fix-cs`).
- [x] PR is ready for a review.
- [ ] Doc for validation configuration
