### PR TITLE
[Docker] Set the default PHP image to PHP7.3 with Node10

### DIFF
--- a/.env
+++ b/.env
@@ -10,8 +10,7 @@ DATABASE_PASSWORD=SetYourOwnPassword
 DATABASE_NAME=ezp
 
 ## Docker images (name and version)
-PHP_IMAGE=ezsystems/php:7.4-v1
-PHP_IMAGE_DEV=ezsystems/php:7.4-v1-dev
+PHP_IMAGE=ezsystems/php:7.3-v2-node10
 NGINX_IMAGE=nginx:stable
 MYSQL_IMAGE=healthcheck/mariadb
 SELENIUM_IMAGE=selenium/standalone-chrome-debug:3.141.59-20200326


### PR DESCRIPTION
Tests running on demo are failing with:
```
Migration failed! Reason: Error in execution of step 2: Argument '$contentTypeGroups[0]' is invalid: expected value to be of type 'eZ\Publish\API\Repository\Values\ContentType\ContentTypeGroup', got 'string' in file /var/www/vendor/ezsystems/ezpublish-kernel/eZ/Publish/Core/Repository/ContentTypeService.php line 483
```
Example job: https://travis-ci.com/github/ezsystems/ezplatform-page-builder/jobs/373035372

This is caused by Travis using PHP 7.4 to run the build - in this PR I adjust this value so that's equal to what's in metarepository: https://github.com/ezsystems/ezplatform/blob/2.5/.env#L13