### PR TITLE
[Composer] Limited ezmigrationbudle to ~5.12.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -71,7 +71,7 @@
         "gregwar/captcha": "^1.1.7",
         "gregwar/captcha-bundle": "^2.0.6",
         "incenteev/composer-parameter-handler": "^2.1.3",
-        "kaliop/ezmigrationbundle": "^5.9",
+        "kaliop/ezmigrationbundle": "~5.12.0",
         "knplabs/knp-menu-bundle": "^2.2.1",
         "monolog/monolog": "^1.25.2",
         "netgen/tagsbundle": "^3.4.1",


### PR DESCRIPTION
Limiting ezmigrationbundle to ~5.12.0 to keep the demo working correctly - with the latest release it fails to install(https://travis-ci.com/github/ezsystems/ezplatform-page-builder/jobs/431650614) with:
```
Migration failed! Reason: Error in execution of step 2: Notice: Undefined variable: label in file /var/www/vendor/kaliop/ezmigrationbundle/Core/EventListener/TracingStepExecutedListener.php line 143

02:17:48 ERROR     [console] Error thrown while running command "ezplatform:install ezplatform-ee-demo". Message: "An error occurred when executing the "'kaliop:migration:migrate --path=src/AppBundle/MigrationVersions/languages.yml -v -n -u'" command." ["exception" => RuntimeException { …},"command" => "ezplatform:install ezplatform-ee-demo","message" => "An error occurred when executing the "'kaliop:migration:migrate --path=src/AppBundle/MigrationVersions/languages.yml -v -n -u'" command."]
```